### PR TITLE
Pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+        name: isort (python)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-.PHONY: qa
-
-## Apply code quality assurance tools.
-qa:
-	black .
-	isort .
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 development = [
     "black",
     "isort",
+    "pre-commit",
     "pytest",
     "tox",
     "sphinx",


### PR DESCRIPTION
This change adds support for [pre-commit](https://pre-commit.com), addressing #40.

Adding pre-commit hooks also made it possible to address #35 by deleting the the top-level makefile. This file was only used to run black and isort, which are now done automatically.

Checklist:

- [x] No pytest errors
- [x] `make analysis` works
- [x] `README.md` up to date
- [x] docs up to date
- [x] `{{cookiecutter.repo_name}}/README.md` up to date
- [x] `investigate.ipynb` up to date
