### PR TITLE
Test cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,8 @@ by running :code:`pip install bibat'[development]'`:
 - pre-commit
 - pytest
 - tox
+- codecov
+- pytest-cov
 - sphinx
 - sphinx-click
 - pydata_sphinx_theme

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,6 +117,8 @@ by running :code:`pip install bibat'[development]'`:
 - pre-commit
 - pytest
 - tox
+- codecov
+- pytest-cov
 - sphinx
 - sphinx-click
 - pydata_sphinx_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,6 @@ init_forbid_extra = true
 init_typed = true
 warn_required_dynamic_aliases = true
 warn_untyped_fields = true
+
+[tool.coverage.run]
+omit = ["bibat/{{cookiecutter.repo_name}}/*"]

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -1,3 +1,9 @@
+"""Unit tests for the cli module.
+
+Adapted from examples here: https://click.palletsprojects.com/en/8.1.x/testing/
+
+"""
+
 import os
 import shutil
 
@@ -7,6 +13,7 @@ from bibat.cli import generate_project
 
 
 def test_generate_project():
+    """Test that the generate_project function works when called normally."""
     runner = CliRunner()
     result = runner.invoke(generate_project)
     assert result.exit_code == 0
@@ -14,6 +21,7 @@ def test_generate_project():
 
 
 def test_generate_project_with_config():
+    """Test that the generate_project function works with a config file."""
     runner = CliRunner()
     f = os.path.join("tests", "data", "example_config.yml")
     result = runner.invoke(generate_project, ["--config-file", f])

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -1,0 +1,21 @@
+import os
+import shutil
+
+from click.testing import CliRunner
+
+from bibat.cli import generate_project
+
+
+def test_generate_project():
+    runner = CliRunner()
+    result = runner.invoke(generate_project)
+    assert result.exit_code == 0
+    shutil.rmtree("project_name")
+
+
+def test_generate_project_with_config():
+    runner = CliRunner()
+    f = os.path.join("tests", "data", "example_config.yml")
+    result = runner.invoke(generate_project, ["--config-file", f])
+    assert result.exit_code == 0
+    shutil.rmtree("my_cool_project")

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pytest-sugar
 commands =
     pip install -e .'[development]'
-    pytest tests --cov --cov-report xml --cov-report term
+    pytest tests --cov=bibat --cov-report xml --cov-report term
 
 [testenv:format]
 description = install black and isort and invoke them on the current folder


### PR DESCRIPTION
This change adds tests for the cli module by copying some examples from the [click documentation](https://click.palletsprojects.com/en/8.1.x/testing/).

I also fixed a problem where coverage would inappropriately add files from the template directory.

Checklist:

- [x] No pytest errors
- [x] `make analysis` works
- [x] `README.md` up to date
- [x] docs up to date
- [x] `{{cookiecutter.repo_name}}/README.md` up to date
- [x] `investigate.ipynb` up to date
