### PR TITLE
Test more pythons

### DIFF
--- a/.github/workflows/test_end_to_end.yml
+++ b/.github/workflows/test_end_to_end.yml
@@ -15,10 +15,10 @@ jobs:
             python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11.3
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.11.3
+        python-version: ${{ matrix.python-version }}
     - name: Install bibat
       run: pip install -e .
     - name: Use bibat

--- a/.github/workflows/test_end_to_end.yml
+++ b/.github/workflows/test_end_to_end.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
         matrix:
             os: [ubuntu-latest, windows-latest]
-
+            python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.11.3


### PR DESCRIPTION
This change adds end to end tests for python 3.9 and 3.10, partially addressing #41.

Checklist:

- [ ] No pytest errors
- [ ] `make analysis` works
- [ ] `README.md` up to date
- [ ] docs up to date
- [ ] `{{cookiecutter.repo_name}}/README.md` up to date
- [ ] `investigate.ipynb` up to date
