### PR TITLE
add lighthouse audit action and language in docs/conf.py

### DIFF
--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -1,0 +1,18 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./docs/_build/html/",
+      "settings": {
+        "skipAudits": ["canonical"]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.8 }],
+        "categories:accessibility": ["error", { "minScore": 0.8 }],
+        "categories:best-practices": ["error", { "minScore": 0.8 }],
+        "categories:seo": ["error", { "minScore": 0.7 }]
+      }
+    }
+  }
+}

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -1,0 +1,30 @@
+# This workflow tests whether the documentation builds correctly and runs a
+# lighthouse audit.
+
+name: Docs check
+
+on: push
+
+jobs:
+  docs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.11.3
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11.3
+    - name: install bibat with development packages
+      run: pip install -e .\[development\]
+    - name: build docs with sphinx
+      run: sphinx-build docs ./docs/_build/html/
+    - name: Audit with Lighthouse
+      uses: treosh/lighthouse-ci-action@v10
+      with:
+        configPath: ".github/workflows/lighthouserc.json"
+        temporaryPublicStorage: true
+        uploadArtifacts: true
+        runs: 3 # Multiple runs to reduce variance

--- a/.github/workflows/test_sphinx.yml
+++ b/.github/workflows/test_sphinx.yml
@@ -6,7 +6,7 @@ on: push
 
 jobs:
   docs:
-    
+
     runs-on: ubuntu-latest
 
     steps:
@@ -22,3 +22,10 @@ jobs:
       run: |
         cd bibat/\{\{cookiecutter.repo_name\}\}
         sphinx-build docs ./docs/_build/html/
+    - name: Audit with Lighthouse
+      uses: treosh/lighthouse-ci-action@v10
+      with:
+        configPath: ".github/workflows/lighthouserc.json"
+        temporaryPublicStorage: true
+        uploadArtifacts: true
+        runs: 3 # Multiple runs to reduce variance

--- a/.github/workflows/test_target_project_docs.yml
+++ b/.github/workflows/test_target_project_docs.yml
@@ -22,10 +22,3 @@ jobs:
       run: |
         cd bibat/\{\{cookiecutter.repo_name\}\}
         sphinx-build docs ./docs/_build/html/
-    - name: Audit with Lighthouse
-      uses: treosh/lighthouse-ci-action@v10
-      with:
-        configPath: ".github/workflows/lighthouserc.json"
-        temporaryPublicStorage: true
-        uploadArtifacts: true
-        runs: 3 # Multiple runs to reduce variance

--- a/.github/workflows/test_target_project_docs.yml
+++ b/.github/workflows/test_target_project_docs.yml
@@ -1,6 +1,6 @@
 # This workflow tests whether projects with sphinx documentation work correctly.
 
-name: Sphinx Check
+name: Test target project docs
 
 on: push
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,11 @@ release = "0.1.5"
 
 root_doc = "index"
 
+# Accessibility recommendation from
+# https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/accessibility.html#what-you-can-do
+
+language = "en"
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
The main change here is to add automatic accessibility checking using the [lighthouse check github action](https://www.foo.software/docs/lighthouse-check-github-action/intro).

This should make it easier to keep track of whether bibat's documentation is accessible as suggested [here](https://github.com/pyOpenSci/software-submission/issues/83#issuecomment-1568163887).

I tried to emulate the approach taken by [pydata-sphinx-theme](https://github.com/pydata/pydata-sphinx-theme).

Checklist:

- [x] No pytest errors
- [x] `make analysis` works
- [x] `README.md` up to date
- [x] docs up to date
- [x] `{{cookiecutter.repo_name}}/README.md` up to date
- [x] `investigate.ipynb` up to date
