### PR TITLE
Customise number of iterations in target project

### DIFF
--- a/bibat/cookiecutter.json
+++ b/bibat/cookiecutter.json
@@ -9,5 +9,6 @@
     "docs_format": ["Quarto", "Sphinx", "No docs"],
     "create_tests_directory": "y",
     "create_dotgithub_directory": "y",
-    "bibat_version": "unknown version"
+    "bibat_version": "unknown version",
+    "n_iter_default": "1000"
 }

--- a/bibat/{{cookiecutter.repo_name}}/inferences/fake_interaction/config.toml
+++ b/bibat/{{cookiecutter.repo_name}}/inferences/fake_interaction/config.toml
@@ -14,11 +14,11 @@ warn-pedantic = true
 
 [sample_kwargs]
 save_warmup = false
-iter_warmup = 2000
-iter_sampling = 2000
+iter_warmup = {{ cookiecutter.n_iter_default }}
+iter_sampling = {{ cookiecutter.n_iter_default }}
 
 [mode_options.kfold]
 n_folds = 5
 chains = 1
-iter_warmup = 1000
-iter_sampling = 1000
+iter_warmup = {{ cookiecutter.n_iter_default | int // 2 }}
+iter_sampling = {{ cookiecutter.n_iter_default | int // 2 }}

--- a/bibat/{{cookiecutter.repo_name}}/inferences/interaction/config.toml
+++ b/bibat/{{cookiecutter.repo_name}}/inferences/interaction/config.toml
@@ -14,11 +14,11 @@ warn-pedantic = true
 
 [sample_kwargs]
 save_warmup = false
-iter_warmup = 2000
-iter_sampling = 2000
+iter_warmup = {{ cookiecutter.n_iter_default | int }}
+iter_sampling = {{ cookiecutter.n_iter_default | int }}
 
 [mode_options.kfold]
 n_folds = 5
 chains = 1
-iter_warmup = 1000
-iter_sampling = 1000
+iter_warmup = {{ cookiecutter.n_iter_default | int // 2 }}
+iter_sampling = {{ cookiecutter.n_iter_default | int // 2 }}

--- a/bibat/{{cookiecutter.repo_name}}/inferences/no_interaction/config.toml
+++ b/bibat/{{cookiecutter.repo_name}}/inferences/no_interaction/config.toml
@@ -14,11 +14,11 @@ warn-pedantic = true
 
 [sample_kwargs]
 save_warmup = false
-iter_warmup = 2000
-iter_sampling = 2000
+iter_warmup = {{ cookiecutter.n_iter_default | int }}
+iter_sampling = {{ cookiecutter.n_iter_default | int }}
 
 [mode_options.kfold]
 n_folds = 5
 chains = 1
-iter_warmup = 1000
-iter_sampling = 1000
+iter_warmup = {{ cookiecutter.n_iter_default | int // 2 }}
+iter_sampling = {{ cookiecutter.n_iter_default | int // 2 }}

--- a/tests/data/example_config.yml
+++ b/tests/data/example_config.yml
@@ -11,3 +11,4 @@ default_context:
   create_dotgithub_directory: y
   install_python_tooling: y
   bibat_version: unknown version
+  n_iter_default: 20


### PR DESCRIPTION
This change adds a new cookiecutter variable for changing the number of iterations that inferences in bibat's target project run. The idea is to save time by setting this low for tests that just check whether everything runs.

Checklist:

- [x] No pytest errors
- [x] `make analysis` works
- [x] `README.md` up to date
- [x] docs up to date
- [x] `{{cookiecutter.repo_name}}/README.md` up to date
- [x] `investigate.ipynb` up to date
