### PR TITLE
Pandera pydantic fix

### DIFF
--- a/bibat/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/bibat/{{cookiecutter.repo_name}}/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "jupyter",
     "numpy",
     "pandas",
-    "pandera@git+https://github.com/unionai-oss/pandera.git@pydantic-v2",
+    "pandera@git+https://github.com/unionai-oss/pandera.git@main",
     "pydantic >= 2.0.0",
     "pyspark",
     "scipy",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2022, Teddy Groves"
 author = "Teddy Groves"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.12"
+release = "0.1.13"
 
 root_doc = "index"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "bibat"
 authors = [
     {name = "Teddy Groves", email = "tedgro@dtu.dk"},
 ]
-version = "0.1.12"
+version = "0.1.13"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
This change continues #64 by changing the target pandera branch.

This is necessary because the `pydantic-v2` branch has been deleted.

Closing #64 will have to wait until the next pandera release.

Checklist:

- [ ] No pytest errors
- [ ] `make analysis` works
- [ ] `README.md` up to date
- [ ] docs up to date
- [ ] `{{cookiecutter.repo_name}}/README.md` up to date
- [ ] `investigate.ipynb` up to date
